### PR TITLE
Fix issues in github paths

### DIFF
--- a/git_downloader.py
+++ b/git_downloader.py
@@ -8,10 +8,12 @@ if sys.version_info < (3, 0):
     # python 2
     import urlparse
     from urllib import urlretrieve
+    from urllib import quote
 else:
     # python 3
     import urllib.parse as urlparse
     from urllib.request import urlretrieve
+    from urllib.parse import quote
 
 def main(args, loglevel):
     logging.basicConfig(format="%(levelname)s: %(message)s", level=loglevel)
@@ -49,7 +51,7 @@ def download_files(args, g, repo_gen):
                     files_to_download.append('https://github.com/%s/raw/master/%s' % (repo.full_name, file.path))
             for file in files_to_download:
                 logging.info('Downloading %s' % file)
-                file = file.replace(" ", "%20")
+                file = quote(file)
                 file_counter += 1
                 filename = posixpath.basename(urlparse.urlsplit(file).path)
                 output_path = os.path.join(args.output_dir, filename)

--- a/git_downloader.py
+++ b/git_downloader.py
@@ -39,8 +39,9 @@ def file_repo_gen(repo_file, g):
 def download_files(args, g, repo_gen):
     file_counter = 0
     for repo in repo_gen:
-        logging.info('Fetching repository: %s (id: %i)' % (repo.full_name, repo.id))
+        
         try:
+            logging.info('Fetching repository: %s (id: %i)' % (repo.full_name, repo.id))
             tree = repo.get_git_tree('master', recursive=True)
             files_to_download = []
             for file in tree.tree:
@@ -48,6 +49,7 @@ def download_files(args, g, repo_gen):
                     files_to_download.append('https://github.com/%s/raw/master/%s' % (repo.full_name, file.path))
             for file in files_to_download:
                 logging.info('Downloading %s' % file)
+                file = file.replace(" ", "%20")
                 file_counter += 1
                 filename = posixpath.basename(urlparse.urlsplit(file).path)
                 output_path = os.path.join(args.output_dir, filename)
@@ -58,7 +60,7 @@ def download_files(args, g, repo_gen):
                 except Exception:
                     logging.exception('Error downloading %s.' % file)
         except Exception:
-             logging.exception('Error fetching repository %s.' % repo.full_name)
+            logging.exception('Error fetching repository.')
 
     args.yara_meta = os.path.join(args.output_dir, args.yara_meta)
     with open(args.yara_meta, 'w') as f:


### PR DESCRIPTION
- Fixed space in file path converting them to %20
`
e.g: INFO: Downloading https://github.com/blacktop/docker-yara/raw/master/w-rules/rules/Loki Rules/crime_malumpos.yar`

- If repository is not available repo is None and repo.full_name raises exception